### PR TITLE
New feature: "top document"

### DIFF
--- a/catalog/templates/catalog/course.html
+++ b/catalog/templates/catalog/course.html
@@ -19,7 +19,8 @@
             {{ course.slug|upper }} {{ course.name }}
         </h1>
         {% if course.is_archive %}
-            <p>Ce cours ne fait plus partie du programme de l'ULB, il est gardé ici uniquement pour des raisons historiques.</p>
+            <p>Ce cours ne fait plus partie du programme de l'ULB, il est gardé ici uniquement pour des raisons
+                historiques.</p>
         {% endif %}
         {% if not course.is_archive %}
             <a class="btn btn-outline-success btn-sm d-inline-flex align-items-center gap-1"
@@ -129,6 +130,15 @@
                                             d="M10.067.87a2.89 2.89 0 0 0-4.134 0l-.622.638-.89-.011a2.89 2.89 0 0 0-2.924 2.924l.01.89-.636.622a2.89 2.89 0 0 0 0 4.134l.637.622-.011.89a2.89 2.89 0 0 0 2.924 2.924l.89-.01.622.636a2.89 2.89 0 0 0 4.134 0l.622-.637.89.011a2.89 2.89 0 0 0 2.924-2.924l-.01-.89.636-.622a2.89 2.89 0 0 0 0-4.134l-.637-.622.011-.89a2.89 2.89 0 0 0-2.924-2.924l-.89.01-.622-.636zm.287 5.984-3 3a.5.5 0 0 1-.708 0l-1.5-1.5a.5.5 0 1 1 .708-.708L7 8.793l2.646-2.647a.5.5 0 0 1 .708.708z"/>
                                     </svg>
                                 {% endif %}
+                                {% if document.total_views > p90_views %}
+
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
+                                        title="Ce document est populaire"
+                                        class="bi bi-gem text-info" viewBox="0 0 16 16">
+                                        <path
+                                            d="M3.1.7a.5.5 0 0 1 .4-.2h9a.5.5 0 0 1 .4.2l2.976 3.974c.149.185.156.45.01.644L8.4 15.3a.5.5 0 0 1-.8 0L.1 5.3a.5.5 0 0 1 0-.6l3-4zm11.386 3.785-1.806-2.41-.776 2.413 2.582-.003zm-3.633.004.961-2.989H4.186l.963 2.995 5.704-.006zM5.47 5.495 8 13.366l2.532-7.876-5.062.005zm-1.371-.999-.78-2.422-1.818 2.425 2.598-.003zM1.499 5.5l5.113 6.817-2.192-6.82L1.5 5.5zm7.889 6.817 5.123-6.83-2.928.002-2.195 6.828z"/>
+                                    </svg>
+                                {% endif %}
                             </div>
                             <div class="fw-light" style="font-size: .7em">
                                 {{ document.user.name }} |
@@ -211,7 +221,8 @@
                     <h3>Il n’y a encore rien dans ce cours…</h3>
                     <p>Les documents que tu trouves sur DocHub ont été partagés par des
                         étudiants comme toi et nous. N'hésite pas à partager tes notes, des questions d'examens
-                        ou même juste un scan des questions du dernier TP. C'est grâce à des petits gestes comme ça que DocHub est si complet !</p>
+                        ou même juste un scan des questions du dernier TP. C'est grâce à des petits gestes comme ça que
+                        DocHub est si complet !</p>
                 </div>
             {% endfor %}
         </ul>


### PR DESCRIPTION
This adds an icon for each document on the course view that is a "top document". At the moment, a top document is a document that has a total number of views + downloads greater that the 90th percentile of views + downloads across all documents on DocHub

<img width="1369" alt="image" src="https://user-images.githubusercontent.com/85785/198238036-a317e78a-c71e-4367-9f57-b977768d9e4f.png">
