### PR TITLE
Switch to psycopg3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ This page tries to contain all changes made on DocHub.
 # Unreleased
 
  * Add CHANGELOG.md and CONTRIBUTING.md
- * Remove unused dependecy on `markdown`
+ * Remove unused dependency on `markdown`
  * Package upgrade
+ * Switch to psycopg3
 
 # 2023.2.0
 

--- a/requirements.in
+++ b/requirements.in
@@ -46,7 +46,7 @@ time-machine
 
 # prod
 redis
-psycopg2-binary
+psycopg[binary,pool]
 python-memcached
 django-jsonfield
 django-jsonfield-compat

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@
 #
 amqp==5.1.1
     # via kombu
+appnope==0.1.3
+    # via ipython
 asgiref==3.6.0
     # via django
 asttokens==2.2.1
@@ -110,6 +112,8 @@ django-stubs-ext==0.8.0
     # via django-stubs
 django-webtest==1.9.10
     # via -r requirements.in
+exceptiongroup==1.1.1
+    # via pytest
 executing==1.2.0
     # via stack-data
 filelock==3.12.0
@@ -193,8 +197,12 @@ prompt-toolkit==3.0.38
     # via
     #   click-repl
     #   ipython
-psycopg2-binary==2.9.6
+psycopg[binary,pool]==3.1.8
     # via -r requirements.in
+psycopg-binary==3.1.8
+    # via psycopg
+psycopg-pool==3.1.7
+    # via psycopg
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
@@ -295,6 +303,8 @@ typing-extensions==4.5.0
     #   django-stubs
     #   django-stubs-ext
     #   mypy
+    #   psycopg
+    #   psycopg-pool
 urllib3==1.26.15
     # via
     #   botocore


### PR DESCRIPTION
Django 4.2 now supports Pyscopg3 and it's going to be the default soon, so let's keep up to date :)